### PR TITLE
searchbox: Drop from sidebar

### DIFF
--- a/_theme/layout.html
+++ b/_theme/layout.html
@@ -33,6 +33,9 @@
             {%- block sidebartoc %}
             {%- include "globaltoc.html" %}
             {%- endblock %}
+            {%- block sidebarsourcelink %}
+            {%- include "sourcelink.html" %}
+            {%- endblock %}
             {%- block sidebarrel %}
             {%- include "relations.html" %}
             {%- endblock %}
@@ -41,9 +44,6 @@
             {%- endif %}
             {%- block sidebarsearch %}
             {%- include "searchbox.html" %}
-            {%- endblock %}
-            {%- block sidebarsourcelink %}
-            {%- include "sourcelink.html" %}
             {%- endblock %}
           {%- endif %}
         </div>

--- a/_theme/sourcelink.html
+++ b/_theme/sourcelink.html
@@ -8,8 +8,8 @@
     :license: BSD, see LICENSE for details.
 #}
 {%- if show_source and has_source and sourcename %}
-  <ul class="this-page-menu list-unstyled text-right">
+  <ul class="this-page-menu list-unstyled text-left">
     <li><a href="{{ pathto('_sources/' + sourcename, true)|e }}"
-           rel="nofollow">{{ _('Show Source') }}</a></li>
+           rel="nofollow">{{ _('Edit on GitHub') }}</a></li>
   </ul>
 {%- endif %}


### PR DESCRIPTION
This drops the searchbox from the sidebar. It's already in the navbar.