### PR TITLE
static: Hide tocwrapper on homepage

### DIFF
--- a/_theme/static/sphinxbootstrap4.css_t
+++ b/_theme/static/sphinxbootstrap4.css_t
@@ -33,6 +33,10 @@ a {
     margin-right: auto;
 }
 
+#acknowledgments .toctree-wrapper {
+    display: none;
+}
+
 {% if theme_navbar_style != "full" %}
 *[id]:before {
   display: block;


### PR DESCRIPTION
This PR ensures the table of contents doesn't appear on the homepage.